### PR TITLE
Config: Update production config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Run the Rails tests with:
 $ rake
 ```
 
+## Production
+
 ### Heroku Setup
 This setup assumes you have a version of the app in a GitHub repository.
 
@@ -42,13 +44,17 @@ This setup assumes you have a version of the app in a GitHub repository.
   - enable review apps
   - enable automatic deployment from master branch
 
-## Production
-
 ### Setup DNS with SSL on Heroku
 1. [Add an alias record to your domain](https://support.dnsimple.com/articles/domain-apex-heroku/#point-using-alias) (we use DNSimple)
 2. [Purchase an SSL certificate](https://dnsimple.com/ssl-certificates)
 3. [Add the SSL cert to Heroku](https://devcenter.heroku.com/articles/ssl-endpoint#setting-up-ssl-on-heroku)
 4. [configure the app to force ssl](https://robots.thoughtbot.com/ssl-for-rails-with-heroku-and-dnsimple#prepare-rails-app)
+
+### Debugging
+In production, [Rails doesn't send errors to stdout by default](https://devcenter.heroku.com/articles/logging#writing-to-your-log). To get those errors sent to the heroku log, `config/environments/development.rb` has been modified with `config.logger = Logger.new(STDOUT)`. With this configuration in place, use the heroku toolbelt to get runtime errors:
+```bash
+$ heroku logs --tail --app app-name
+```
 
 ## License
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,4 +1,5 @@
 This is the listings of events
+<%= test_error %>
 <% @events.each do |event| %>
   <h2><%= event.name %></h2>
 <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,7 +1,4 @@
 This is the listings of events
-<% if Rails.env == "production" %>
-  <%= errorHere %>
-<% end %>
 <% @events.each do |event| %>
   <h2><%= event.name %></h2>
 <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,5 +1,7 @@
 This is the listings of events
-<%= test_error %>
+<% if Rails.env == "production" %>
+  <%= errorHere %>
+<% end %>
 <% @events.each do |event| %>
   <h2><%= event.name %></h2>
 <% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   # config.log_tags = [ :subdomain, :uuid ]
 
   # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  config.logger = Logger.new(STDOUT)
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
Redirect logger to STDOUT. This should allow us to see app errors with
`heroku logs`... I think.

@catheraaine @boomingbrake @BC3209       