### PR TITLE
MVP Stuff: flip the toggle arrow & remove "filter events by"

### DIFF
--- a/app/assets/stylesheets/styles/_event-filters.scss
+++ b/app/assets/stylesheets/styles/_event-filters.scss
@@ -54,15 +54,6 @@
     }
   }
 
-  &__heading {
-    margin: ($margin * 4) 0;
-    text-align: center;
-
-    @media (max-width: $break-large) {
-      display: none;
-    }
-  }
-
   &__group {
     display: flex;
     flex-flow: row wrap;

--- a/app/assets/stylesheets/styles/_event-filters.scss
+++ b/app/assets/stylesheets/styles/_event-filters.scss
@@ -24,7 +24,20 @@
       display: none;
       visibility: hidden;
     }
+
+    .toggle-arrow {
+      stroke: $highlight;
+      stroke-width: 1;
+      fill: none;
+      transform: rotateZ(2deg);
+      transition: transform .3s ease-out .3s;
+
+      .filters-open & {
+        transform: rotateZ(182deg);
+      }
+    }
   }
+
 
   &__filters {
     margin: 0 ($margin * 4);
@@ -35,10 +48,10 @@
       height: auto;
       overflow: visible;
     }
-  }
 
-  .filters-open &__filters {
-    height: auto;
+    .filters-open & {
+      height: auto;
+    }
   }
 
   &__heading {

--- a/app/views/events/_filters.html.erb
+++ b/app/views/events/_filters.html.erb
@@ -9,7 +9,6 @@
   </svg>
 </button>
 <div id="event-filters__filters" class="event-filters__filters">
-  <div class="event-filters__heading">Filter Events by:</div>
 
   <div class="event-filters__group" role="group" aria-labelledby="filter-group-heading-topics">
     <h1 class="event-filters__group-heading" id="filter-group-heading-topics">Topics:</h1>

--- a/app/views/events/_filters.html.erb
+++ b/app/views/events/_filters.html.erb
@@ -1,14 +1,10 @@
 <button class="event-filters__toggle-button">
   Filter Events
-  <svg width="12px" height="8px" viewBox="0 0 12 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <svg class="toggle-arrow" width="12px" height="8px" viewBox="0 0 12 8" version="1.1" xmlns="http://www.w3.org/2000/svg">
     <title>Toggle Arrow</title>
     <desc>Toggles the filter menu</desc>
-    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-      <g transform="translate(-255.000000, -260.000000)" stroke="#F8E81C">
-        <g id="toggle-arrow" transform="translate(5.000000, 255.000000)">
-          <polyline points="251.199219 5.95703125 256.273391 12.0312033 260.80343 5.50116394"></polyline>
-        </g>
-      </g>
+    <g>
+      <polyline points="1.199219 0.95703125 6.273391 7.0312033 10.80343 0.50116394"></polyline>
     </g>
   </svg>
 </button>


### PR DESCRIPTION
@BC3209 @boomingbrake @catheraaine       
This includes a cleanup of the toggle arrow svg
![flip it](http://i.giphy.com/ErdfMetILIMko.gif)