### PR TITLE
Fix: Check query params exist before checking params.length

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,7 +32,7 @@ class Event < ActiveRecord::Base
   end
 
   def tag_queried(queried_tags)
-    if queried_tags.length > 0 then
+    if queried_tags && queried_tags.length > 0 then
       'hidden' if entire_tag_list.length == (entire_tag_list - queried_tags.collect { |tag| uri_encode(tag) }).length
     end
   end


### PR DESCRIPTION
@boomingbrake tag_queried method was breaking the single event pages. Small Fix.

@BC3209 @catheraaine if anyone wants to check the review app and make sure single event pages are working, then this should be merge-able.