### PR TITLE
Chore: Remove site-wide auth, set on admin only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env, then create login usernames and keys for yourself.
+
+ADMIN_USER=
+ADMIN_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /log/*
 !/log/.keep
 /tmp
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ end
 group :development, :test do
   gem 'byebug'
   gem 'jasmine-rails'
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,10 @@ GEM
     dalli (2.7.6)
     debug_inspector (0.0.2)
     docile (1.1.5)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     execjs (2.6.0)
     font-awesome-rails (4.6.2.0)
@@ -234,6 +238,7 @@ DEPENDENCIES
   carrierwave
   codeclimate-test-reporter
   dalli
+  dotenv-rails
   jasmine-rails
   jbuilder (~> 2.0)
   jquery-rails

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Using Rails and PostgreSQL
   - `$ rake db:create`
   - `$ rake db:migrate`
 
+### Rails Admin
+This project uses Rails Admin for database entry. To set up your admin username and password, see the `.env.example` file in the project root folder. 
+
 ### Testing
 Run the Rails tests with:
 ```bash

--- a/app.json
+++ b/app.json
@@ -8,10 +8,10 @@
     "DATABASE_URL": {
       "required": true
     },
-    "DEV_USER_NAME": {
+    "ADMIN_USER": {
       "required": true
     },
-    "DEV_PASSWORD": {
+    "ADMIN_PASSWORD": {
       "required": true
     }
   },

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,5 +2,4 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  http_basic_authenticate_with name: ENV["DEV_USER_NAME"], password: ENV["DEV_PASSWORD"] if Rails.env.production?
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,5 +1,11 @@
 RailsAdmin.config do |config|
 
+  config.authorize_with do
+    authenticate_or_request_with_http_basic('Admin Login') do |username, password|
+      username == ENV["DEV_USER_NAME"] && password == ENV["DEV_PASSWORD"]
+    end
+  end
+
   ### Popular gems integration
 
   ## == Devise ==

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -2,7 +2,7 @@ RailsAdmin.config do |config|
 
   config.authorize_with do
     authenticate_or_request_with_http_basic('Admin Login') do |username, password|
-      username == ENV["DEV_USER_NAME"] && password == ENV["DEV_PASSWORD"]
+      username == ENV["ADMIN_USER"] && password == ENV["ADMIN_PASSWORD"]
     end
   end
 


### PR DESCRIPTION
@catheraaine @boomingbrake @BC3209 I did this on a fresh branch to avoid conflicts. I also just reused the env vars we were using for the previous auth. (same creds)